### PR TITLE
Fix parsing and validation of metadata

### DIFF
--- a/aiohttp_tus/utils.py
+++ b/aiohttp_tus/utils.py
@@ -60,7 +60,14 @@ def parse_upload_metadata(metadata_header: str) -> MappingStrBytes:
     for item in metadata_header.split(","):
         if not item:
             continue
-        key, value = item.split()
+        # The key and value MUST be separated by **a** space.
+        metadata = item.split(' ', 1)
+        # The value MAY be empty. In these cases, the space, which would normally separate the key and the value, MAY be left out.
+        if len(metadata) == 1:
+            key = metadata
+            value = ""
+        else:
+            key, value = header_data
         metadata[key] = base64.b64decode(value)
 
     return CIMultiDict(metadata)


### PR DESCRIPTION
Applies the specification more precisely: allow empty values, do not
remove leading spaces from values, if separator is more than a single
space, do not fail on additional value contents with more spaces.

This also fixes an Internal Server Error in the empty value case. It's
allowed for key to stand on its own without any space separator. The
code relied on split yielding exactly two items.